### PR TITLE
Added \a, \b; other miscellaneous operators

### DIFF
--- a/commands.tex
+++ b/commands.tex
@@ -136,6 +136,8 @@
 \newcommand{\F}{\mathbb{F}}
 \newcommand{\C}{\mathbb{C}}
 \newcommand{\Q}{\mathbb{Q}}
+\newcommand{\a}{\alpha}
+\newcommand{\b}{\beta}
 \newcommand{\e}{\varepsilon}
 \newcommand{\p}{\varphi}
 \newcommand{\bfb}{\mathbf{b}}
@@ -174,6 +176,22 @@
 \DeclareMathOperator{\Null}{Null}
 \DeclareMathOperator{\Range}{Range}
 \DeclareMathOperator{\Ann}{Ann}
+\DeclareMathOperator{\End}{End} % Set of endomorphisms
+\DeclareMathOperator{\Hom}{Hom} % Set of homomorphisms
+\DeclareMathOperator{\GL}{GL} % General linear group
+\DeclareMathOperator{\Rad}{Rad} % Radical 
+\DeclareMathOperator{\ord}{ord} % Order
+\DeclareMathOperator{\Frac}{Frac} % Fractional field
+\DeclareMathOperator{\Pic}{Pic} % Picard group
+\DeclareMathOperator{\Char}{char} % Characteristic of a field (Char is taken)
+\DeclareMathOperator{\Mob}{M\ddot ob} % Set of M\"obius transformations
+\DeclareMathOperator{\ind}{ind} % "Index", or discrete logarithm
+\DeclareMathOperator{\Gal}{Gal} % Galois group
+\DeclareMathOperator{\Res}{Res}
+\DeclareMathOperator{\Ind}{Ind} 
+\DeclareMathOperator{\Triv}{Triv} % Trivial representation
+\DeclareMathOperator{\coker}{coker}
+\DeclareMathOperator{\Ext}{Ext}
 
 % Define a question environment
 \NewDocumentEnvironment{question}{m o}


### PR DESCRIPTION
Added `\a` for `\alpha`, `\b` for `\beta`, and a bunch of miscellaneous operators pertaining to field, representation and algebraic number theory