### PR TITLE
Add new commands and reorganise

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -1,0 +1,12 @@
+\DeclareMathOperator{\End}{End} % Set of endomorphisms
+\DeclareMathOperator{\Hom}{Hom} % Set of homomorphisms
+\DeclareMathOperator{\Rad}{Rad} % Radical 
+\DeclareMathOperator{\Frac}{Frac} % Fractional field
+\DeclareMathOperator{\Pic}{Pic} % Picard group
+\DeclareMathOperator{\Char}{char} % Characteristic of a field (Char is taken)
+\DeclareMathOperator{\Mob}{M\ddot ob} % Set of M\"obius transformations
+\DeclareMathOperator{\ind}{ind} % "Index", or discrete logarithm
+\DeclareMathOperator{\Gal}{Gal} % Galois group
+\DeclareMathOperator{\Res}{Res}
+\DeclareMathOperator{\Triv}{Triv} % Trivial representation
+\DeclareMathOperator{\coker}{coker}

--- a/commands.tex
+++ b/commands.tex
@@ -31,10 +31,10 @@
 
 % Cleveref package for nice references
 \usepackage[capitalise,noabbrev]{cleveref} % capitalise figure names and don't abbreviate
-\crefname{equation}{}{} % Remove 'equation' from equation references
 
 % Tikz library for drawings
 \usepackage{tikz}
+\usepackage{pgfplots}
 \usetikzlibrary{arrows.meta} % For drawing arrows in tikz
 \usetikzlibrary{calc} % For calculating coordinates in tikz
 
@@ -85,9 +85,11 @@
 \newtheorem{lem}{Lemma}
 \newtheorem{prop}{Proposition}
 \newtheorem{computation}{Computation}
+\newtheorem*{rmk}{Remark}
 
 \theoremstyle{definition}
 \newtheorem{defn}{Definition}
+\newtheorem*{example}{Example}
 
 \theoremstyle{case}
 \newtheorem{case}{Case}
@@ -132,6 +134,14 @@
 \renewcommand{\P}[0]{\ensuremath{\mathcal{P}}}
 \newcommand{\NP}[0]{\ensuremath{\mathcal{NP}}}
 
+% for function restrictions, use as \restr{f}{A}
+\newcommand\restr[2]{{% we make the whole thing an ordinary symbol
+  \left.\kern-\nulldelimiterspace % automatically resize the bar with \right
+  #1 % the function
+  \vphantom{\big|} % pretend it's a little taller at normal size
+  \right|_{#2} % this is the delimiter
+  }}
+
 % Defining maths symbol shortcuts
 \newcommand{\N}{\mathbb{N}}
 \newcommand{\Z}{\mathbb{Z}}
@@ -160,6 +170,9 @@
 \newcommand{\sub}{\leqslant}
 \newcommand{\nsub}{\triangleleft}
 \newcommand{\card}[1]{\overline{\overline{#1}}}
+\newcommand{\vect}[1]{\boldsymbol{#1}}
+\newcommand*{\dd}{\mathop{\mathrm{d}\!}}
+\newcommand{\code}[1]{\texttt{#1}}
 
 % Defining some maths operators
 \DeclareMathOperator{\tr}{tr}
@@ -195,6 +208,9 @@
 \DeclareMathOperator{\Triv}{Triv} % Trivial representation
 \DeclareMathOperator{\coker}{coker}
 \DeclareMathOperator{\Ext}{Ext}
+\DeclareMathOperator*{\EV}{\mathbb{E}}
+\DeclareMathOperator*{\argmax}{arg\,max}
+\DeclareMathOperator*{\argmin}{arg\,min}
 
 % Define a question environment
 \NewDocumentEnvironment{question}{m o}

--- a/commands.tex
+++ b/commands.tex
@@ -149,8 +149,6 @@
 \newcommand{\F}{\mathbb{F}}
 \newcommand{\C}{\mathbb{C}}
 \newcommand{\Q}{\mathbb{Q}}
-\newcommand{\a}{\alpha}
-\newcommand{\b}{\beta}
 \newcommand{\e}{\varepsilon}
 \newcommand{\p}{\varphi}
 \newcommand{\bfb}{\mathbf{b}}
@@ -192,21 +190,9 @@
 \DeclareMathOperator{\Null}{Null}
 \DeclareMathOperator{\Range}{Range}
 \DeclareMathOperator{\Ann}{Ann}
-\DeclareMathOperator{\End}{End} % Set of endomorphisms
-\DeclareMathOperator{\Hom}{Hom} % Set of homomorphisms
 \DeclareMathOperator{\GL}{GL} % General linear group
-\DeclareMathOperator{\Rad}{Rad} % Radical 
 \DeclareMathOperator{\ord}{ord} % Order
-\DeclareMathOperator{\Frac}{Frac} % Fractional field
-\DeclareMathOperator{\Pic}{Pic} % Picard group
-\DeclareMathOperator{\Char}{char} % Characteristic of a field (Char is taken)
-\DeclareMathOperator{\Mob}{M\ddot ob} % Set of M\"obius transformations
-\DeclareMathOperator{\ind}{ind} % "Index", or discrete logarithm
-\DeclareMathOperator{\Gal}{Gal} % Galois group
-\DeclareMathOperator{\Res}{Res}
 \DeclareMathOperator{\Ind}{Ind} 
-\DeclareMathOperator{\Triv}{Triv} % Trivial representation
-\DeclareMathOperator{\coker}{coker}
 \DeclareMathOperator{\Ext}{Ext}
 \DeclareMathOperator*{\EV}{\mathbb{E}}
 \DeclareMathOperator*{\argmax}{arg\,max}

--- a/commands.tex
+++ b/commands.tex
@@ -10,6 +10,8 @@
 \usepackage{amssymb, amsmath, amsthm} % https://tex.stackexchange.com/a/32102
 \usepackage{mathtools} % makes maths nicer
 \usepackage[margin=1in]{geometry} % Gives smaller margins
+\usepackage{algorithm} 
+\usepackage[noend]{algpseudocode} % algorithm and algopseudocode need to load before hyperref and caption (I think)
 \usepackage[colorlinks=true,linkcolor=blue,citecolor=magenta]{hyperref} % For urls and to make references nicer
 
 % http://www.ams.org/arc/tex/amscls/amsthdoc.pdf for theorems
@@ -82,6 +84,7 @@
 \newtheorem{thm}{Theorem}
 \newtheorem{lem}{Lemma}
 \newtheorem{prop}{Proposition}
+\newtheorem{computation}{Computation}
 
 \theoremstyle{definition}
 \newtheorem{defn}{Definition}

--- a/complex_analysis.tex
+++ b/complex_analysis.tex
@@ -7,3 +7,5 @@
 \DeclareMathOperator{\Ln}{Ln} % complex Log
 \DeclareMathOperator{\re}{Re} % real part - \Re is the Real symbol
 \DeclareMathOperator{\im}{Im} % complex part - \Im is the imaginary symbol
+\DeclareMathOperator{\res}{res} % residue
+\DeclareMathOperator{\wind}{ind} % winding number

--- a/complex_analysis.tex
+++ b/complex_analysis.tex
@@ -9,3 +9,4 @@
 \DeclareMathOperator{\im}{Im} % complex part - \Im is the imaginary symbol
 \DeclareMathOperator{\res}{res} % residue
 \DeclareMathOperator{\wind}{ind} % winding number
+\DeclareMathOperator{\Conf}{Conf} % conformal maps


### PR DESCRIPTION
This change adds complex analysis commands in a separate file and common commands in main file. It also reorganises the main file by moving some less common algebra commands to a separate file. It was found that `\a` and `\b` are causing double definition errors so they are removed. Reasons for directly removing them are:

- they provide limited value: shortening `\alpha` to `\a` and `\beta` to `\b` provides limited utility;
- they silence wanted compiler warnings (at least for me): I often accidentally add a `\` infront of words, having the compiler shout at me is preferred;
- it is not difficult to just define them at the top of the file, or have a personal shortcut file for each user.